### PR TITLE
Feature/gen/extended search and build

### DIFF
--- a/example/ExampleProject/ExampleProject.csproj
+++ b/example/ExampleProject/ExampleProject.csproj
@@ -3,6 +3,9 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <AssemblyVersion>1.1.0.0</AssemblyVersion>
+    <FileVersion>1.1.0.0</FileVersion>
+    <Version>1.1.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/example/ExampleProject/ExampleProject.csproj
+++ b/example/ExampleProject/ExampleProject.csproj
@@ -7,15 +7,12 @@
 
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.12.3" />
+    <PackageReference Include="Google.Protobuf.Tools" Version="3.12.3" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\sRPC\sRPC.csproj" />
   </ItemGroup>
-
-  <!--<ItemGroup>
-    <Protobuf Include="**/*.proto" OutputDir="%(RelativeDir)" CompileOutputs="false" />
-  </ItemGroup>-->
 
   <ItemGroup>
     <None Update="empty_service.proto" GrpcServices="None" />
@@ -26,14 +23,8 @@
     <!--copy sRPCgen-->
     <Exec Command="dotnet build -v q --configuration Release --nologo $(SolutionDir)sRPCgen/sRPCgen.csproj" />
     <Exec Command="cp -f $(SolutionDir)sRPCgen/bin/Release/netcoreapp3.1/sRPCgen* $(TargetDir)/" />
-    <!--Build empty_service.proto-->
-    <Exec Command="protoc -I$(ProjectDir) -o$(ProjectDir)empty_service.proto.bin --csharp_out=$(ProjectDir) --csharp_opt=base_namespace=$(TargetName),file_extension=.g.cs $(ProjectDir)\empty_service.proto" />
-    <Exec Command="$(TargetDir)sRPCgen --output-dir=$(ProjectDir) --namespace-base=ExampleProject --file-extension=.service.cs --file=$(ProjectDir)empty_service.proto.bin" />
-    <Delete Files="empty_service.proto.bin" />
-    <!--Build simple_service.proto-->
-    <Exec Command="protoc -I$(ProjectDir) -o$(ProjectDir)simple_service.proto.bin --csharp_out=$(ProjectDir) --csharp_opt=base_namespace=$(TargetName),file_extension=.g.cs $(ProjectDir)\simple_service.proto" />
-    <Exec Command="$(TargetDir)sRPCgen --output-dir=$(ProjectDir) --namespace-base=ExampleProject --file-extension=.service.cs --file=$(ProjectDir)simple_service.proto.bin" />
-    <Delete Files="simple_service.proto.bin" />
+    <!--build protos-->
+    <Exec Command="$(TargetDir)sRPCgen --search-dir=$(ProjectDir) --output-dir=$(ProjectDir) --namespace-base=ExampleProject --file-extension=.service.cs --build-protoc --proto-import=$(ProjectDir) --proto-extension=.g.cs" />
   </Target>
 
 </Project>

--- a/sRPC/sRPC.csproj
+++ b/sRPC/sRPC.csproj
@@ -2,6 +2,9 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
+    <AssemblyVersion>1.1.0.0</AssemblyVersion>
+    <FileVersion>1.1.0.0</FileVersion>
+    <Version>1.1.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sRPCgen/Properties/launchSettings.json
+++ b/sRPCgen/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "sRPCgen": {
       "commandName": "Project",
-      "commandLineArgs": "--output-dir=S:\\Documents\\Projects\\Argus\\docs\\api\\bin --file=S:\\Documents\\Projects\\Argus\\docs\\api\\test"
+      "commandLineArgs": "--search-dir=S:\\Documents\\Projects\\Argus\\docs\\api\\argus --output-dir=S:\\Documents\\Projects\\Argus\\docs\\api\\bin --namespace-base=Argus.Api --file-extension=.service.cs --build-protoc --proto-import=S:\\Documents\\Projects\\Argus\\docs\\api --proto-extension=.g.cs"
     }
   }
 }

--- a/sRPCgen/sRPCgen.csproj
+++ b/sRPCgen/sRPCgen.csproj
@@ -3,6 +3,9 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <AssemblyVersion>1.1.0.0</AssemblyVersion>
+    <FileVersion>1.1.0.0</FileVersion>
+    <Version>1.1.0</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
sRPC has added the following parameters:
- `--search.dir=PROTO_DIR`: will search a certain directory for input files. The `--file` option is not needed for this
- `--build-protoc`: Integration of protoc. No longer need to run protoc before this application. This will generate the binary description and the C# files automaticly. (protoc has to be in PATH)
- `--proto-import`: This will add imports for protoc
- `--proto-extension`: The file extension protoc should use for its own files

With this sRPC is now smarter and the build process for proto files could be simplified.