### PR TITLE
extend sRPC.Tools. close #10. Move Version to 2.2.0.

### DIFF
--- a/example/ExampleProject/ExampleProject.csproj
+++ b/example/ExampleProject/ExampleProject.csproj
@@ -5,12 +5,9 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <!--<RestoreSources>$(RestoreSources);$(SolutionDir)sRPC.Tools/bin/Release;https://api.nuget.org/v3/index.json</RestoreSources>
+    <Use_Srpc_Tools_Version>2.1.6</Use_Srpc_Tools_Version>-->
   </PropertyGroup>
-
-  <ItemGroup>
-    <None Remove="empty_service.proto" />
-    <None Remove="simple_service.proto" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.12.3" />
@@ -22,9 +19,9 @@
     </PackageReference>
   </ItemGroup>
 
-  <ItemGroup>
-    <Protobuf Include="empty_service.proto" />
-    <Protobuf Include="simple_service.proto" />
-  </ItemGroup>
+  <PropertyGroup>
+    <Srpc_AutoSearchProj>true</Srpc_AutoSearchProj>
+    <Srpc_EmptySupport>true</Srpc_EmptySupport>
+  </PropertyGroup>
 
 </Project>

--- a/sRPC.Tools/build/sRPC.CSharp.xml
+++ b/sRPC.Tools/build/sRPC.CSharp.xml
@@ -89,7 +89,7 @@
       </StringProperty.Metadata>
     </StringProperty>
 
-    <EnumProperty Name="Access" DisplayName="Class Access"
+    <!--<EnumProperty Name="Access" DisplayName="Class Access"
                   Category="Protobuf"
                   Description="Public or internal access modifier on generated classes.">
       <EnumValue Name="Public" DisplayName="Public" IsDefault="true" />
@@ -98,7 +98,7 @@
         <DataSource ItemType="Protobuf" SourceOfDefaultValue="AfterContext"
                     PersistenceStyle="Attribute" HasConfigurationCondition="false" />
       </EnumProperty.DataSource>
-    </EnumProperty>
+    </EnumProperty>-->
 
     <StringProperty Name="NamespaceBase" DisplayName="Namespace Base"
                     Category="sRPC"

--- a/sRPC.Tools/build/sRPC.Tools.targets
+++ b/sRPC.Tools/build/sRPC.Tools.targets
@@ -63,6 +63,12 @@
       <Protobuf_ProtocFullPath Condition=" '$(Protobuf_ProtocFullPath)' == '' ">$(PROTOBUF_PROTOC)</Protobuf_ProtocFullPath>
       <Protobuf_SrpcFullPath Condition=" '$(Protobuf_SrpcFullPath)' == '' ">$(PROTOBUF_SRPC)</Protobuf_SrpcFullPath>
 
+      <Srpc_NamespaceBase Condition=" '$(Srpc_NamespaceBase)' == '' ">$(SRPC_NAMESPACE_BASE)</Srpc_NamespaceBase>
+      <Srpc_SrpcExt Condition=" '$(Srpc_SrpcExt)' == '' ">$(SRPC_SRPC_EXT)</Srpc_SrpcExt>
+      <Srpc_ProtoExt Condition=" '$(Srpc_ProtoExt)' == '' ">$(SRPC_PROTO_EXT)</Srpc_ProtoExt>
+      <Srpc_AutoSearchProj Condition=" '$(Srpc_AutoSearchProj)' == '' ">$(SRPC_AUTO_SEARCH_PROJ)</Srpc_AutoSearchProj>
+      <Srpc_EmptySupport Condition=" '$(Srpc_EmptySupport)' == '' ">$(SRPC_EMPTY_SUPPORT)</Srpc_EmptySupport>
+
       <!-- Next try OS and CPU resolved by ProtoPlatform. -->
       <Protobuf_ToolsOs Condition=" '$(Protobuf_ToolsOs)' == '' ">$(_Protobuf_ToolsOs)</Protobuf_ToolsOs>
       <Protobuf_ToolsCpu Condition=" '$(Protobuf_ToolsCpu)' == '' ">$(_Protobuf_ToolsCpu)</Protobuf_ToolsCpu>
@@ -74,6 +80,12 @@
            >$(Protobuf_PackagedToolsPath)/$(Protobuf_ToolsOs)_$(Protobuf_ToolsCpu)/sRPCgen.exe</Protobuf_SrpcFullPath>
       <Protobuf_SrpcFullPath Condition=" '$(Protobuf_SrpcFullPath)' == '' "
            >$(Protobuf_PackagedToolsPath)/$(Protobuf_ToolsOs)_$(Protobuf_ToolsCpu)/sRPCgen</Protobuf_SrpcFullPath>
+
+      <Srpc_NamespaceBase Condition=" '$(Srpc_NamespaceBase)' == '' ">$(TargetName)</Srpc_NamespaceBase>
+      <Srpc_SrpcExt Condition=" '$(Srpc_SrpcExt)' == '' ">.service.cs</Srpc_SrpcExt>
+      <Srpc_ProtoExt Condition=" '$(Srpc_ProtoExt)' == '' ">.g.cs</Srpc_ProtoExt>
+      <Srpc_AutoSearchProj Condition=" '$(Srpc_AutoSearchProj)' != 'true' ">false</Srpc_AutoSearchProj>
+      <Srpc_EmptySupport Condition=" '$(Srpc_EmptySupport)' != 'true' ">false</Srpc_EmptySupport>
       
     </PropertyGroup>
 
@@ -88,7 +100,7 @@
   </Target>
 
   <Target Name="srpc_Generate"
-          Condition=" '@(Protobuf)' != '' "
+          Condition=" '@(Protobuf)' != '' or $(Srpc_AutoSearchProj) == 'true' "
           DependsOnTargets=" Protobuf_ResolvePlatform ">
     <Message Text="Generate SRPC" />
     <Error Condition=" '$(Protobuf_SrpcFullPath)' == '' "
@@ -101,6 +113,11 @@
       ProtocPath="$(Protobuf_ProtocFullPath)"
       ProjectPath="$(ProjectDir)"
       StandardImportsPath="$(Protobuf_StandardImportsPath)"
+      SrpcNamespaceBase="$(Srpc_NamespaceBase)"
+      SrpcSrpcExt="$(Srpc_SrpcExt)"
+      SrpcProtoExt="$(Srpc_ProtoExt)"
+      SrpcAutoSearchProj="$(Srpc_AutoSearchProj)"
+      SrpcEmptySupport="$(Srpc_EmptySupport)"
       />
   </Target>
 

--- a/sRPC/sRPC.csproj.include
+++ b/sRPC/sRPC.csproj.include
@@ -2,7 +2,7 @@
 <Project>
   
   <PropertyGroup>
-    <Version>2.1.0</Version>
+    <Version>2.2.0</Version>
     <AssemblyVersion>$(Version).0</AssemblyVersion>
     <FileVersion>$(Version).0</FileVersion>
 
@@ -14,8 +14,8 @@
          The test projects will not use these versions. They will not use the sRPC NuGet
          packages at all. The test projects link these directly.
     -->
-    <Use_Srpc_Version>2.0.0</Use_Srpc_Version>
-    <Use_Srpc_Tools_Version>2.0.0</Use_Srpc_Tools_Version>
+    <Use_Srpc_Version>2.1.0</Use_Srpc_Version>
+    <Use_Srpc_Tools_Version>2.1.0</Use_Srpc_Tools_Version>
   </PropertyGroup>
   
 </Project>


### PR DESCRIPTION
add auto-search support and empty-support for the sRPC.Tools that was only avaible for sRPCgen.