### PR TITLE
fix uncomplete transmission for some Stream implementations

### DIFF
--- a/example/ExampleProject/SimpleService.g.cs
+++ b/example/ExampleProject/SimpleService.g.cs
@@ -42,7 +42,11 @@ namespace ExampleProject {
 
   }
   #region Messages
-  public sealed partial class RandonNumberRequest : pb::IMessage<RandonNumberRequest> {
+  public sealed partial class RandonNumberRequest : pb::IMessage<RandonNumberRequest>
+  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      , pb::IBufferMessage
+  #endif
+  {
     private static readonly pb::MessageParser<RandonNumberRequest> _parser = new pb::MessageParser<RandonNumberRequest>(() => new RandonNumberRequest());
     private pb::UnknownFieldSet _unknownFields;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -158,6 +162,9 @@ namespace ExampleProject {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      output.WriteRawMessage(this);
+    #else
       if (Count != 0) {
         output.WriteRawTag(8);
         output.WriteInt32(Count);
@@ -173,7 +180,29 @@ namespace ExampleProject {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
+    #endif
     }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
+      if (Count != 0) {
+        output.WriteRawTag(8);
+        output.WriteInt32(Count);
+      }
+      if (MinValue != 0) {
+        output.WriteRawTag(16);
+        output.WriteInt32(MinValue);
+      }
+      if (MaxValue != 0) {
+        output.WriteRawTag(24);
+        output.WriteInt32(MaxValue);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(ref output);
+      }
+    }
+    #endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public int CalculateSize() {
@@ -212,6 +241,9 @@ namespace ExampleProject {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void MergeFrom(pb::CodedInputStream input) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      input.ReadRawMessage(this);
+    #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -232,11 +264,42 @@ namespace ExampleProject {
           }
         }
       }
+    #endif
     }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+        switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
+            break;
+          case 8: {
+            Count = input.ReadInt32();
+            break;
+          }
+          case 16: {
+            MinValue = input.ReadInt32();
+            break;
+          }
+          case 24: {
+            MaxValue = input.ReadInt32();
+            break;
+          }
+        }
+      }
+    }
+    #endif
 
   }
 
-  public sealed partial class RandomNumberResponse : pb::IMessage<RandomNumberResponse> {
+  public sealed partial class RandomNumberResponse : pb::IMessage<RandomNumberResponse>
+  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      , pb::IBufferMessage
+  #endif
+  {
     private static readonly pb::MessageParser<RandomNumberResponse> _parser = new pb::MessageParser<RandomNumberResponse>(() => new RandomNumberResponse());
     private pb::UnknownFieldSet _unknownFields;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -317,11 +380,25 @@ namespace ExampleProject {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      output.WriteRawMessage(this);
+    #else
       number_.WriteTo(output, _repeated_number_codec);
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
+    #endif
     }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
+      number_.WriteTo(ref output, _repeated_number_codec);
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(ref output);
+      }
+    }
+    #endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public int CalculateSize() {
@@ -344,6 +421,9 @@ namespace ExampleProject {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void MergeFrom(pb::CodedInputStream input) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      input.ReadRawMessage(this);
+    #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -357,7 +437,27 @@ namespace ExampleProject {
           }
         }
       }
+    #endif
     }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+        switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
+            break;
+          case 10:
+          case 8: {
+            number_.AddEntriesFrom(ref input, _repeated_number_codec);
+            break;
+          }
+        }
+      }
+    }
+    #endif
 
   }
 

--- a/example/ExampleProject/SimpleService.service.cs
+++ b/example/ExampleProject/SimpleService.service.cs
@@ -134,10 +134,7 @@ namespace ExampleProject
             }
         }
 
-        public abstract stt::Task<ExampleProject.RandomNumberResponse> GetRandomNumber(ExampleProject.RandonNumberRequest request);
-
-        public virtual stt::Task<ExampleProject.RandomNumberResponse> GetRandomNumber(ExampleProject.RandonNumberRequest request, st::CancellationToken cancellationToken)
-            => GetRandomNumber(request);
+        public abstract stt::Task<ExampleProject.RandomNumberResponse> GetRandomNumber(ExampleProject.RandonNumberRequest request, st::CancellationToken cancellationToken);
     }
 }
 

--- a/example/ExampleProject/SimpleServiceServer.cs
+++ b/example/ExampleProject/SimpleServiceServer.cs
@@ -1,11 +1,14 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace ExampleProject
 {
     public class SimpleServiceServer : SimpleServiceServerBase
     {
-        public override Task<RandomNumberResponse> GetRandomNumber(RandonNumberRequest request)
+        public override Task<RandomNumberResponse> GetRandomNumber(
+            RandonNumberRequest request, 
+            CancellationToken cancellationToken)
         {
             var rng = new Random();
             var result = new RandomNumberResponse();

--- a/sRPC/ApiBase.cs
+++ b/sRPC/ApiBase.cs
@@ -92,7 +92,18 @@ namespace sRPC
                     buffer = new byte[length];
                     try
                     {
-                        await Input.ReadAsync(buffer, 0, buffer.Length, cancellationToken.Token);
+                        var readed = 0;
+                        while (readed < length)
+                        {
+                            var r = await Input.ReadAsync(
+                                buffer, 
+                                readed, 
+                                buffer.Length - readed, 
+                                cancellationToken.Token);
+                            readed += r;
+                            if (r == 0)
+                                break;
+                        }
                     }
                     catch (IOException e)
                     {

--- a/sRPC/sRPC.csproj.include
+++ b/sRPC/sRPC.csproj.include
@@ -2,7 +2,7 @@
 <Project>
   
   <PropertyGroup>
-    <Version>2.5.0</Version>
+    <Version>2.5.1</Version>
     <AssemblyVersion>$(Version).0</AssemblyVersion>
     <FileVersion>$(Version).0</FileVersion>
 
@@ -14,8 +14,8 @@
          The test projects will not use these versions. They will not use the sRPC NuGet
          packages at all. The test projects link these directly.
     -->
-    <Use_Srpc_Version>2.4.1</Use_Srpc_Version>
-    <Use_Srpc_Tools_Version>2.4.1</Use_Srpc_Tools_Version>
+    <Use_Srpc_Version>2.5.0</Use_Srpc_Version>
+    <Use_Srpc_Tools_Version>2.5.0</Use_Srpc_Tools_Version>
   </PropertyGroup>
   
 </Project>


### PR DESCRIPTION
Some Stream implementations like `System.Net.Security.SslStream` wont read the whole buffer at once. In the case of `System.Net.Security.SslStream` it will read a maximum of 16355 Bytes at once. This will brake the messages and create connection issues.